### PR TITLE
Added fake-request with host and scheme

### DIFF
--- a/Controller/TaskController.php
+++ b/Controller/TaskController.php
@@ -206,9 +206,17 @@ class TaskController extends RestController implements ClassResourceInterface, S
      */
     public function postAction(Request $request)
     {
+        $data = array_merge(
+            [
+                'scheme' => $request->getScheme(),
+                'host' => $request->getHost(),
+            ],
+            array_filter($request->request->all())
+        );
+
         $manager = $this->getTaskManager();
         $task = $this->get('serializer')->deserialize(
-            json_encode(array_filter($request->request->all())),
+            json_encode($data),
             Task::class,
             'json',
             DeserializationContext::create()->setGroups(['api'])
@@ -230,8 +238,17 @@ class TaskController extends RestController implements ClassResourceInterface, S
      */
     public function putAction($id, Request $request)
     {
+        $data = array_merge(
+            [
+                'id' => $id,
+                'scheme' => $request->getScheme(),
+                'host' => $request->getHost(),
+            ],
+            array_filter($request->request->all())
+        );
+
         $task = $this->get('serializer')->deserialize(
-            json_encode(array_merge(['id' => $id], $request->request->all())),
+            json_encode($data),
             Task::class,
             'json',
             DeserializationContext::create()->setGroups(['api'])

--- a/Entity/DoctrineTaskRepository.php
+++ b/Entity/DoctrineTaskRepository.php
@@ -59,6 +59,14 @@ class DoctrineTaskRepository extends EntityRepository implements TaskRepositoryI
     /**
      * {@inheritdoc}
      */
+    public function findByTaskId($id)
+    {
+        return $this->findOneBy(['taskId' => $id]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function countFutureTasks($entityClass, $entityId, $locale = null)
     {
         $queryBuilder = $this->createQueryBuilder('task')

--- a/Entity/Task.php
+++ b/Entity/Task.php
@@ -57,6 +57,16 @@ class Task implements TaskInterface
     private $taskId;
 
     /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var string
+     */
+    private $scheme;
+
+    /**
      * {@inheritdoc}
      */
     public function getId()
@@ -206,6 +216,50 @@ class Task implements TaskInterface
     public function setTaskId($taskId)
     {
         $this->taskId = $taskId;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Set host.
+     *
+     * @param string $host
+     *
+     * @return $this
+     */
+    public function setHost($host)
+    {
+        $this->host = $host;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScheme()
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * Set scheme.
+     *
+     * @param string $scheme
+     *
+     * @return $this
+     */
+    public function setScheme($scheme)
+    {
+        $this->scheme = $scheme;
 
         return $this;
     }

--- a/EventSubscriber/PHPTaskEventSubscriber.php
+++ b/EventSubscriber/PHPTaskEventSubscriber.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Sulu\Bundle\AutomationBundle\EventSubscriber;
+
+use Sulu\Bundle\AutomationBundle\Tasks\Model\TaskRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Task\Event\Events;
+use Task\Event\TaskEvent;
+
+/**
+ * Fake-Request handling for tasks.
+ */
+class PHPTaskEventSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TaskRepositoryInterface
+     */
+    private $taskRepository;
+
+    /**
+     * @param RequestStack $requestStack
+     * @param TaskRepositoryInterface $taskRepository
+     */
+    public function __construct(RequestStack $requestStack, TaskRepositoryInterface $taskRepository)
+    {
+        $this->requestStack = $requestStack;
+        $this->taskRepository = $taskRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::TASK_BEFORE => ['pushRequest'],
+            Events::TASK_AFTER => ['popRequest'],
+        ];
+    }
+
+    /**
+     * Create and push new request to requests-stack.
+     *
+     * @param TaskEvent $event
+     */
+    public function pushRequest(TaskEvent $event)
+    {
+        $task = $this->taskRepository->findByTaskId($event->getTask()->getUuid());
+        if (!$task) {
+            // current task is not managed by this bundle
+
+            return;
+        }
+
+        $request = new Request(
+            [],
+            [],
+            ['_task_id' => $event->getTask()->getUuid()],
+            [],
+            [],
+            ['SERVER_NAME' => $task->getHost(), 'HTTPS' => $task->getScheme() === 'http' ? 'off' : 'on']
+        );
+
+        $this->requestStack->push($request);
+    }
+
+    /**
+     * Pop request from request stack.
+     *
+     * @param TaskEvent $event
+     */
+    public function popRequest(TaskEvent $event)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (!$request || $request->attributes->get('_task_id') !== $event->getTask()->getUuid()) {
+            // current request was not created for current task
+
+            return;
+        }
+
+        $this->requestStack->pop();
+    }
+}

--- a/Handler/BaseDocumentHandler.php
+++ b/Handler/BaseDocumentHandler.php
@@ -65,10 +65,9 @@ abstract class BaseDocumentHandler implements AutomationTaskHandlerInterface
      */
     public function configureOptionsResolver(OptionsResolver $optionsResolver)
     {
-        return $optionsResolver->setRequired(['id', 'locale'])->setAllowedTypes('id', 'string')->setAllowedTypes(
-            'locale',
-            'string'
-        );
+        return $optionsResolver->setRequired(['id', 'locale'])
+            ->setAllowedTypes('id', 'string')
+            ->setAllowedTypes('locale', 'string');
     }
 
     /**

--- a/Resources/config/doctrine/Task.orm.xml
+++ b/Resources/config/doctrine/Task.orm.xml
@@ -14,6 +14,9 @@
         <field name="schedule" type="datetime" column="schedule"/>
         <field name="locale" type="string" column="locale" length="5"/>
 
+        <field name="scheme" type="string" column="scheme" length="5"/>
+        <field name="host" type="string" column="host"/>
+
         <field name="taskId" type="guid" nullable="true">
             <options>
                 <option name="references">

--- a/Resources/config/serializer/Task.xml
+++ b/Resources/config/serializer/Task.xml
@@ -12,6 +12,9 @@
         <property name="created" type="DateTime" expose="true" groups="fullTask,partialTask"/>
         <property name="changed" type="DateTime" expose="true" groups="fullTask,partialTask"/>
 
+        <property name="scheme" type="string" expose="true" groups="fullTask,partialTask,api"/>
+        <property name="host" type="string" expose="true" groups="fullTask,partialTask,api"/>
+
         <virtual-property method="getCreatorFullname" name="creator" serialized-name="creator" groups="fullTask,partialTask"/>
         <virtual-property method="getChangerFullname" name="changer" serialized-name="changer" groups="fullTask,partialTask"/>
     </class>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -39,6 +39,13 @@
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
+        <service id="sulu_automation.task.event_subscriber" class="Sulu\Bundle\AutomationBundle\EventSubscriber\PHPTaskEventSubscriber">
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu.repository.task"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <!-- FIXME hack to enable doctrine object constructor -->
         <!--
           could be fixed in serializer by changing JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass:49

--- a/Tasks/Model/TaskInterface.php
+++ b/Tasks/Model/TaskInterface.php
@@ -86,6 +86,20 @@ interface TaskInterface extends AuditableInterface
     public function setTaskId($taskId);
 
     /**
+     * Returns host.
+     *
+     * @return string
+     */
+    public function getHost();
+
+    /**
+     * Returns scheme.
+     *
+     * @return string
+     */
+    public function getScheme();
+
+    /**
      * Returns creator full-name.
      *
      * @return string

--- a/Tasks/Model/TaskRepositoryInterface.php
+++ b/Tasks/Model/TaskRepositoryInterface.php
@@ -49,6 +49,15 @@ interface TaskRepositoryInterface
     public function findById($id);
 
     /**
+     * Find task-entity with given php-task id.
+     *
+     * @param int $id
+     *
+     * @return TaskInterface
+     */
+    public function findByTaskId($id);
+
+    /**
      * Count tasks which will be called in the future in given entity.
      *
      * @param string $entityClass

--- a/Tests/Functional/Controller/TaskControllerTest.php
+++ b/Tests/Functional/Controller/TaskControllerTest.php
@@ -343,6 +343,8 @@ class TaskControllerTest extends SuluTestCase
         $task->setLocale('de');
         $task->setHandlerClass(FirstHandler::class);
         $task->setSchedule(new \DateTime());
+        $task->setScheme('http');
+        $task->setHost('sulu.io');
 
         $taskManager = $this->getContainer()->get('sulu_automation.tasks.manager');
         $taskManager->create($task);

--- a/Tests/Unit/EventSubscriber/PHPTaskEventSubscriberTest.php
+++ b/Tests/Unit/EventSubscriber/PHPTaskEventSubscriberTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AutomationBundle\Tests\Unit\EventSubscriber;
+
+use Prophecy\Argument;
+use Sulu\Bundle\AutomationBundle\EventSubscriber\PHPTaskEventSubscriber;
+use Sulu\Bundle\AutomationBundle\Tasks\Model\TaskInterface;
+use Sulu\Bundle\AutomationBundle\Tasks\Model\TaskRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Task\Event\Events;
+use Task\Event\TaskEvent;
+use Task\TaskInterface as PHPTaskInterface;
+
+/**
+ * Unit tests for php-task event-subscriber.
+ */
+class PHPTaskEventSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TaskRepositoryInterface
+     */
+    private $taskRepository;
+
+    /**
+     * @var PHPTaskEventSubscriber
+     */
+    private $eventSubscriber;
+
+    protected function setUp()
+    {
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->taskRepository = $this->prophesize(TaskRepositoryInterface::class);
+
+        $this->eventSubscriber = new PHPTaskEventSubscriber(
+            $this->requestStack->reveal(), $this->taskRepository->reveal()
+        );
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $eventNames = [Events::TASK_BEFORE, Events::TASK_AFTER];
+        foreach ($this->eventSubscriber->getSubscribedEvents() as $eventName => $functions) {
+            $this->assertTrue(in_array($eventName, $eventNames));
+
+            foreach ($functions as $function) {
+                $this->assertTrue(method_exists($this->eventSubscriber, $function));
+            }
+        }
+    }
+
+    public function testPushRequest()
+    {
+        $event = $this->createEvent();
+
+        $task = $this->prophesize(TaskInterface::class);
+        $task->getScheme()->willReturn('http');
+        $task->getHost()->willReturn('sulu.io');
+        $this->taskRepository->findByTaskId($event->getTask()->getUuid())->willReturn($task->reveal());
+
+        $this->requestStack->push(
+            Argument::that(
+                function (Request $request) use ($event) {
+                    return $request->getScheme() === 'http'
+                           && $request->getHost() === 'sulu.io'
+                           && $request->attributes->get('_task_id') === $event->getTask()->getUuid();
+                }
+            )
+        )->shouldBeCalled();
+
+        $this->eventSubscriber->pushRequest($event);
+    }
+
+    public function testPushRequestHttps()
+    {
+        $event = $this->createEvent();
+
+        $task = $this->prophesize(TaskInterface::class);
+        $task->getScheme()->willReturn('https');
+        $task->getHost()->willReturn('sulu.io');
+        $this->taskRepository->findByTaskId($event->getTask()->getUuid())->willReturn($task->reveal());
+
+        $this->requestStack->push(
+            Argument::that(
+                function (Request $request) use ($event) {
+                    return $request->getScheme() === 'https'
+                           && $request->getHost() === 'sulu.io'
+                           && $request->attributes->get('_task_id') === $event->getTask()->getUuid();
+                }
+            )
+        )->shouldBeCalled();
+
+        $this->eventSubscriber->pushRequest($event);
+    }
+
+    public function testPushRequestNotManaged()
+    {
+        $event = $this->createEvent();
+
+        $this->taskRepository->findByTaskId($event->getTask()->getUuid())->willReturn(null);
+
+        $this->requestStack->push(Argument::any())->shouldNotBeCalled();
+
+        $this->eventSubscriber->pushRequest($event);
+    }
+
+    public function testPopRequest()
+    {
+        $event = $this->createEvent();
+
+        $request = new Request([], [], ['_task_id' => $event->getTask()->getUuid()]);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $this->requestStack->pop()->shouldBeCalled();
+
+        $this->eventSubscriber->popRequest($event);
+    }
+
+    public function testPopRequestNoTaskId()
+    {
+        $event = $this->createEvent();
+
+        $request = new Request();
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $this->requestStack->pop()->shouldNotBeCalled();
+
+        $this->eventSubscriber->popRequest($event);
+    }
+
+    protected function createEvent()
+    {
+        $task = $this->prophesize(PHPTaskInterface::class);
+        $task->getUuid()->willReturn('123-123-123');
+
+        $event = $this->prophesize(TaskEvent::class);
+        $event->getTask()->willReturn($task->reveal());
+
+        return $event->reveal();
+    }
+}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,15 @@
+# Upgrade
+
+## dev-develop
+
+### Fake-Request for task handlers
+ 
+The task was extended by the column `host` and `scheme` to fake a similar request. This will ensure that the Cache
+will be delete correctly.
+
+Update your database by running following SQL-Statement:
+
+```sql
+ALTER TABLE au_task ADD scheme VARCHAR(5) DEFAULT '' NOT NULL, ADD host VARCHAR(255) DEFAULT '' NOT NULL;
+ALTER TABLE au_task CHANGE scheme scheme VARCHAR(5) NOT NULL, CHANGE host host VARCHAR(255) NOT NULL;
+```


### PR DESCRIPTION
This PR adds the columns `scheme` and `host`. This will be used by an event subscriber to push and pop a fake request. This will ensure that the cache will be cleared on the correct host and scheme.

Will also fix #7