### PR TITLE
Update task listbuilder definition for 2.0

### DIFF
--- a/Resources/config/list-builder/Task.xml
+++ b/Resources/config/list-builder/Task.xml
@@ -23,17 +23,17 @@
     </orm:joins>
 
     <properties>
-        <property name="id" list:translation="public.id" display="no" list:sortable="false">
+        <property name="id" list:translation="public.id" visibility="no" list:sortable="false">
             <orm:field-name>id</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
 
-        <property name="locale" display="never">
+        <property name="locale" visibility="never">
             <orm:field-name>locale</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
 
-        <property name="handlerClass" display="never">
+        <property name="handlerClass" visibility="never">
             <orm:field-name>handlerClass</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
@@ -41,30 +41,30 @@
         <property name="status" list:translation="public.status" list:sortable="false"/>
 
         <property name="taskName" list:translation="sulu_automation.task.name" list:type="translation"
-                  display="always" list:sortable="false"/>
+                  visibility="always" list:sortable="false"/>
 
-        <property name="taskId" display="never">
+        <property name="taskId" visibility="never">
             <orm:field-name>taskId</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
 
-        <property name="schedule" list:translation="sulu_automation.task.schedule" display="always"
+        <property name="schedule" list:translation="sulu_automation.task.schedule" visibility="always"
                   list:type="datetime">
             <orm:field-name>schedule</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
 
-        <property name="entityClass" display="never" list:sortable="false">
+        <property name="entityClass" visibility="never" list:sortable="false">
             <orm:field-name>entityClass</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
 
-        <property name="entityId" display="never" list:sortable="false">
+        <property name="entityId" visibility="never" list:sortable="false">
             <orm:field-name>entityId</orm:field-name>
             <orm:entity-name>%sulu.model.task.class%</orm:entity-name>
         </property>
 
-        <concatenation-property name="creator" display="always" orm:glue=" "
+        <concatenation-property name="creator" visibility="always" orm:glue=" "
                                 list:translation="sulu_automation.list.creator" list:sortable="false">
             <orm:field>
                 <orm:field-name>firstName</orm:field-name>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | n/a
| Related issues/PRs | #22
| License | MIT

#### What's in this PR?

An update to the listbuilder definition of the task entity. Replaces display="*display*" with visiblility="*visibility*".

#### Why?

Using the develop branch with Sulu 2.x caused no fields to appear in the automation tab.

![screenshot from 2018-08-28 09-08-39](https://user-images.githubusercontent.com/11940560/44706495-029bf800-aaa2-11e8-864f-d7b81e662192.png)