### PR TITLE
updated force-lowest for symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/dependency-injection": "^3.4",
         "symfony/http-foundation": "^3.4",
         "symfony/http-kernel": "^3.4",
-        "symfony/force-lowest": "^3.4",
+        "symfony/force-lowest": "^3.4 || ^4.0",
         "sulu/sulu": "^2.0",
         "php-task/task-bundle": "^2.0",
         "willdurand/hateoas-bundle": "^1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

Added symfony version 4.0 to the `symfony/force-lowest` in the composer.json file.