### PR TITLE
Add admin priority and check for view existence

### DIFF
--- a/Admin/AutomationAdmin.php
+++ b/Admin/AutomationAdmin.php
@@ -31,6 +31,11 @@ class AutomationAdmin extends Admin
 
     const EDIT_FORM_VIEW = 'sulu_automation.edit_form';
 
+    public static function getPriority(): int
+    {
+        return -512;
+    }
+
     /**
      * @var ViewBuilderFactoryInterface
      */
@@ -58,6 +63,10 @@ class AutomationAdmin extends Admin
 
     public function configureViews(ViewCollection $viewCollection): void
     {
+        if (!$viewCollection->has(PageAdmin::EDIT_FORM_VIEW)) {
+            return;
+        }
+
         $automationViewBuilder = new AutomationViewBuilder(static::LIST_VIEW, '/automation');
         $automationViewBuilder
             ->setEntityClass(BasePageDocument::class)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

Used the priority to ensure that the admin will be called after the page admin to be able to check for existence.