### PR TITLE
Flush changes to database in TaskController::putAction

### DIFF
--- a/Controller/TaskController.php
+++ b/Controller/TaskController.php
@@ -277,7 +277,7 @@ class TaskController extends AbstractRestController implements ClassResourceInte
     {
         $entityClass = (string) $request->query->get('entityClass');
         $entityId = (string) $request->query->get('entityId');
-        $locale = $request->query->get('locale');
+        $locale = $request->query->has('locale') ? (string) $request->query->get('locale') : null;
 
         return $this->handleView($this->view([
             'count' => $this->automationTaskRepository->countFutureTasks($entityClass, $entityId, $locale),
@@ -354,6 +354,7 @@ class TaskController extends AbstractRestController implements ClassResourceInte
         $task->setSchedule($dateTime);
         $task = $this->taskManager->update($task);
 
+        $this->entityManager->merge($task);
         $this->entityManager->flush();
 
         return $this->handleView($this->view($task));

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -86,19 +86,6 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
-        <!-- FIXME hack to enable doctrine object constructor -->
-        <!--
-          could be fixed in serializer by changing JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass:49
-          from "->replaceArgument(0, new Reference($previousId[$service]))"
-          to   "->replaceArgument(1, new Reference($previousId[$service]))"
-        -->
-        <service id="jms_serializer.object_constructor" alias="sulu_automation.object_constructor" public="false"/>
-        <service id="sulu_automation.object_constructor" class="JMS\Serializer\Construction\DoctrineObjectConstructor"
-                 public="false">
-            <argument type="service" id="doctrine"/>
-            <argument type="service" id="jms_serializer.unserialize_object_constructor"/>
-        </service>
-
         <service id="sulu_content.automation.publish_handler"
                  class="Sulu\Bundle\AutomationBundle\Handler\DocumentPublishHandler">
             <argument type="service" id="sulu_document_manager.document_manager"/>

--- a/Tests/Functional/Controller/TaskControllerTest.php
+++ b/Tests/Functional/Controller/TaskControllerTest.php
@@ -290,7 +290,14 @@ class TaskControllerTest extends SuluTestCase
         $this->assertArrayHasKey('id', $responseData);
         $this->assertEquals($handlerClass, $responseData['handlerClass']);
         $this->assertEquals($date->format('Y-m-d\TH:i:s'), $responseData['schedule']);
+        $this->assertNotNull($responseData['taskId']);
         $this->assertEquals($locale, $responseData['locale']);
+
+        $taskManager = $this->getContainer()->get('sulu_automation.tasks.manager');
+        $task = $taskManager->findById($responseData['id']);
+        $this->assertEquals($handlerClass, $task->getHandlerClass());
+        $this->assertEqualsWithDelta($date, $task->getSchedule(), 1);
+        $this->assertNotNull($task->getTaskId());
 
         return $responseData;
     }
@@ -325,7 +332,14 @@ class TaskControllerTest extends SuluTestCase
         $this->assertEquals($postData['id'], $responseData['id']);
         $this->assertEquals($handlerClass, $responseData['handlerClass']);
         $this->assertEquals($date->format('Y-m-d\TH:i:s'), $responseData['schedule']);
+        $this->assertNotNull($responseData['taskId']);
         $this->assertEquals(FirstHandler::TITLE, $responseData['taskName']);
+
+        $taskManager = $this->getContainer()->get('sulu_automation.tasks.manager');
+        $task = $taskManager->findById($postData['id']);
+        $this->assertEquals($handlerClass, $task->getHandlerClass());
+        $this->assertEqualsWithDelta($date, $task->getSchedule(), 1);
+        $this->assertNotNull($task->getTaskId());
     }
 
     public function testGet()


### PR DESCRIPTION
It looks like the `TaskController::putAction` does not flush the changes to the database at the moment. I suspect that this is caused by the following change in the `sulu/sulu` package:
https://github.com/sulu/sulu/pull/5414