### PR TITLE
Fix task badge to also show past tasks which have not been executed yet

### DIFF
--- a/Controller/TaskController.php
+++ b/Controller/TaskController.php
@@ -280,7 +280,7 @@ class TaskController extends AbstractRestController implements ClassResourceInte
         $locale = $request->query->has('locale') ? (string) $request->query->get('locale') : null;
 
         return $this->handleView($this->view([
-            'count' => $this->automationTaskRepository->countFutureTasks($entityClass, $entityId, $locale),
+            'count' => $this->automationTaskRepository->countPendingTasks($entityClass, $entityId, $locale),
         ]));
     }
 

--- a/Entity/DoctrineTaskRepository.php
+++ b/Entity/DoctrineTaskRepository.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Query\Expr\Join;
 use Sulu\Bundle\AutomationBundle\Tasks\Model\TaskInterface;
 use Sulu\Bundle\AutomationBundle\Tasks\Model\TaskRepositoryInterface;
 use Task\TaskBundle\Entity\TaskExecution;
-use Task\TaskBundle\Entity\Task as TaskBundleTask;
 
 /**
  * Task-Repository implementation for doctrine.
@@ -30,7 +29,10 @@ class DoctrineTaskRepository extends EntityRepository implements TaskRepositoryI
     {
         $class = $this->_entityName;
 
-        return new $class();
+        /** @var TaskInterface $entity */
+        $entity = new $class();
+
+        return $entity;
     }
 
     /**

--- a/Tasks/Model/TaskRepositoryInterface.php
+++ b/Tasks/Model/TaskRepositoryInterface.php
@@ -13,8 +13,6 @@ namespace Sulu\Bundle\AutomationBundle\Tasks\Model;
 
 /**
  * Interface for task-repository.
- *
- * @method int countPendingTasks(string $entityClass, string $entityId, string $locale = null)
  */
 interface TaskRepositoryInterface
 {
@@ -44,9 +42,16 @@ interface TaskRepositoryInterface
     public function findByTaskId(string $id): ?TaskInterface;
 
     /**
-     * Count tasks which will be called in the future in given entity.
+     * @deprecated
+     *
+     * Count tasks which have a schedule date in the future
      */
     public function countFutureTasks(string $entityClass, string $entityId, string $locale = null): int;
+
+    /**
+     * Count pending tasks which have not been executed yet.
+     */
+    public function countPendingTasks(string $entityClass, string $entityId, string $locale = null): int;
 
     /**
      * Revert given task-entity.

--- a/Tasks/Model/TaskRepositoryInterface.php
+++ b/Tasks/Model/TaskRepositoryInterface.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\AutomationBundle\Tasks\Model;
 
 /**
  * Interface for task-repository.
+ *
+ * @method int countPendingTasks(string $entityClass, string $entityId, string $locale = null)
  */
 interface TaskRepositoryInterface
 {

--- a/Tests/Functional/Controller/TaskControllerTest.php
+++ b/Tests/Functional/Controller/TaskControllerTest.php
@@ -373,7 +373,7 @@ class TaskControllerTest extends SuluTestCase
 
         $responseData = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(2, $responseData['count']);
+        $this->assertEquals(3, $responseData['count']);
     }
 
     public function testGetWithoutCreator()

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+# 2.x
+
+A new method has been added to the `TaskRepositoryInterface`
+
+```php
+public function countPendingTasks(string $entityClass, string $entityId, string $locale = null): int
+```
+
 ## 2.0.0
 
 Following dependencies are updated and have new minimum requirements:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Fix task badge to also show past tasks which have not been executed yet

#### Why?

Currently, the tab badge only shows the amount of tasks in the future. But if a task for a past date has not been executed yet, it will not be taken into account, but it will still be executed when running `task:run`.

