### PR TITLE
Set fom key default to task_details

### DIFF
--- a/Metadata/FormMetadataLoader.php
+++ b/Metadata/FormMetadataLoader.php
@@ -26,7 +26,7 @@ use Task\TaskBundle\Handler\TaskHandlerFactory;
 class FormMetadataLoader implements FormMetadataLoaderInterface
 {
     const TASK_DETAILS_VIEW = 'task_details';
-    
+
     /**
      * @var TranslatorInterface
      */

--- a/Metadata/FormMetadataLoader.php
+++ b/Metadata/FormMetadataLoader.php
@@ -25,6 +25,8 @@ use Task\TaskBundle\Handler\TaskHandlerFactory;
  */
 class FormMetadataLoader implements FormMetadataLoaderInterface
 {
+    const TASK_DETAILS_VIEW = 'task_details';
+    
     /**
      * @var TranslatorInterface
      */
@@ -48,12 +50,13 @@ class FormMetadataLoader implements FormMetadataLoaderInterface
      */
     public function getMetadata(string $key, string $locale, array $metadataOptions): ?MetadataInterface
     {
-        if ('task_details' !== $key) {
+        if (self::TASK_DETAILS_VIEW !== $key) {
             return null;
         }
 
         /** @var FormMetaData $form */
         $form = new FormMetadata();
+        $form->setKey(self::TASK_DETAILS_VIEW);
 
         // Single Select
         $singleSelectHandler = new FieldMetadata('handlerClass');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Sets the form key default to `task_details` in `FormMetadataLoader`.

#### Why?

In combination with Sulu 2.4, ContentBundle and AutomationBundle the form key was not set when in the admin view a new task was created.
