### PR TITLE
Fix null returned instead of object when getting task_details form metadata

### DIFF
--- a/Metadata/FormMetadataLoader.php
+++ b/Metadata/FormMetadataLoader.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Bundle\AutomationBundle\TaskHandler\AutomationTaskHandlerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Task\TaskBundle\Handler\TaskHandlerFactory;
@@ -57,6 +58,9 @@ class FormMetadataLoader implements FormMetadataLoaderInterface
         /** @var FormMetadata $form */
         $form = new FormMetadata();
         $form->setKey(self::TASK_DETAILS_VIEW);
+
+        $schemaMetadata = new SchemaMetadata();
+        $form->setSchema($schemaMetadata);
 
         // Single Select
         $singleSelectHandler = new FieldMetadata('handlerClass');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #73
| Related issues/PRs | --
| License | MIT

#### What's in this PR?

Fixes a critical PHP error when retrieving `task_details` form metadata while attempting to create a new task:

```
TypeError:
Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::getSchema():
Return value must be of type Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata, null returned
```