### PR TITLE
Deprecate rest routing and provide Symfony Routing alternative

### DIFF
--- a/Controller/TaskController.php
+++ b/Controller/TaskController.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\AutomationBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\AutomationBundle\Admin\AutomationAdmin;
@@ -40,7 +39,7 @@ use Task\Storage\TaskRepositoryInterface;
 /**
  * Provides api for tasks.
  */
-class TaskController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
+class TaskController extends AbstractRestController implements SecuredControllerInterface
 {
     /**
      * @var string[]

--- a/Resources/config/routing_api.yaml
+++ b/Resources/config/routing_api.yaml
@@ -1,0 +1,71 @@
+sulu_automation.get_tasks_fields:
+    path: '/tasks/fields.{_format}'
+    options: { expose: true }
+    methods: GET
+    controller: 'sulu_automation.task_controller::cgetFieldsAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.get_tasks:
+    path: '/tasks.{_format}'
+    options: { expose: true }
+    methods: GET
+    controller: 'sulu_automation.task_controller::cgetAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.get_task:
+    path: '/tasks/{id}.{_format}'
+    options: { expose: true }
+    methods: GET
+    controller: 'sulu_automation.task_controller::getAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.get_task_count:
+    path: '/task/count.{_format}'
+    options: { expose: true }
+    methods: GET
+    controller: 'sulu_automation.task_controller::getCountAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.post_task:
+    path: '/tasks.{_format}'
+    options: { expose: true }
+    methods: POST
+    controller: 'sulu_automation.task_controller::postAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.put_task:
+    path: '/tasks/{id}.{_format}'
+    options: { expose: true }
+    methods: PUT
+    controller: 'sulu_automation.task_controller::putAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.delete_task:
+    path: '/tasks/{id}.{_format}'
+    options: { expose: true }
+    methods: DELETE
+    controller: 'sulu_automation.task_controller::deleteAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_automation.delete_tasks:
+    path: '/tasks.{_format}'
+    options: { expose: true }
+    methods: DELETE
+    controller: 'sulu_automation.task_controller::cdeleteAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }

--- a/Resources/config/routing_api.yml
+++ b/Resources/config/routing_api.yml
@@ -1,3 +1,4 @@
+# Deprecated use the routing_api.yaml file
 sulu_automation.tasks:
     type: rest
     name_prefix: sulu_automation.

--- a/Tests/Application/config/routing.yml
+++ b/Tests/Application/config/routing.yml
@@ -1,9 +1,3 @@
-sulu_automation:
-    resource: '@SuluAutomationBundle/Resources/config/routing.yml'
-    type: rest
-    prefix: /automation
-
 sulu_automation_api:
-    resource: '@SuluAutomationBundle/Resources/config/routing_api.yml'
-    type: rest
+    resource: '@SuluAutomationBundle/Resources/config/routing_api.yaml'
     prefix: /api

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,24 @@
 # Upgrade
 
+## 2.2.0
+
+### Deprecate usage of fos rest routing
+
+We are no longer considering the [fos rest routing](https://github.com/handcraftedinthealps/RestRoutingBundle) as a best practice.
+All bundles should use the Symfony routing system instead.
+
+Inside your `config/routes/sulu_admin.yaml` and `config/routes/sulu_website.yaml`, you can remove the fos rest routing configuration.
+First, remove all instances of `type: rest` and also replace `.yml` with `.yaml`:
+
+```diff
+# config/routes/sulu_admin.yaml`
+ sulu_automation_api:
+-    type: rest
+-    resource: '@SuluAutomationBundle/Resources/config/routing_api.yml'
++    resource: '@SuluAutomationBundle/Resources/config/routing_api.yaml'
+     prefix: /admin/api
+```
+
 ## 2.0.1
 
 A new method has been added to the `TaskRepositoryInterface`


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | refs sulu/sulu#7434
| License | MIT

#### What's in this PR?
Replacing rest routing with Symfony routing.

#### Why?
It's not part of sulu anymore and will be removed in 3.0 anyways.
