### PR TITLE
Fix Automation view for multiple groups

### DIFF
--- a/Admin/AutomationAdmin.php
+++ b/Admin/AutomationAdmin.php
@@ -98,7 +98,7 @@ class AutomationAdmin extends Admin
             ) {
                 $viewCollection->add(
                     $this->automationViewBuilderFactory->createTaskListViewBuilder(
-                        ArticleAdmin::EDIT_TABS_VIEW . '.automation',
+                        ArticleAdmin::EDIT_TABS_VIEW . '.automation' . '_' . $groupIdentifier,
                         '/automation',
                         ArticleInterface::class,
                     )


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

This MR fixes the automation view if there is more than one article group

#### Why?

In case there is more than one group, only the latest group will get the view, as the name was the same for all groups

