### PR TITLE
Add PHP 8.5 CI Job

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -30,7 +30,9 @@ jobs:
 
                     - php-version: '8.4'
                       dependency-versions: 'highest'
-                      composer-options: '--ignore-platform-reqs'
+
+                    - php-version: '8.5'
+                      dependency-versions: 'highest'
 
         services:
             mysql:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Add PHP 8.5 CI Job.

#### Why?

More stable tests suite to find issues with PHP 8.5 or dependency versions with Min requirement for PHP 8.5.