### PR TITLE
Fix GroupProvider for Sulu 3.0.7

### DIFF
--- a/Admin/AutomationAdmin.php
+++ b/Admin/AutomationAdmin.php
@@ -88,7 +88,7 @@ class AutomationAdmin extends Admin
 
     private function configureArticleView(ViewCollection $viewCollection): void
     {
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         foreach ($groups as $group) {
             $groupIdentifier = $group->identifier;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "jms/serializer-bundle": "^3.0 || ^4.0 || ^5.0",
         "php-task/php-task": "^3.0.1",
         "php-task/task-bundle": "^4.0.1",
-        "sulu/sulu": "^3.0.7",
+        "sulu/sulu": "^3.0",
         "symfony/config": "^6.4 || ^7.1",
         "symfony/dependency-injection": "^6.4 || ^7.1",
         "symfony/deprecation-contracts": "^2.5 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "jms/serializer-bundle": "^3.0 || ^4.0 || ^5.0",
         "php-task/php-task": "^3.0.1",
         "php-task/task-bundle": "^4.0.1",
-        "sulu/sulu": "^3.0",
+        "sulu/sulu": "^3.0.7",
         "symfony/config": "^6.4 || ^7.1",
         "symfony/dependency-injection": "^6.4 || ^7.1",
         "symfony/deprecation-contracts": "^2.5 || ^3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes (raises minimum sulu/sulu version)
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | sulu/sulu#8836
| License | MIT

#### What's in this PR?

Adopts the new `GroupProviderInterface::getGroups(string $key)` signature shipped by sulu/sulu 3.0.7 and bumps the `sulu/sulu` requirement to `^3.0.7`.

#### Why?

Without this change, `AutomationAdmin::configureArticleView()` calls `getGroups()` with no argument and fatals with a `TypeError` against sulu/sulu 3.0.7+. The call now passes `ArticleInterface::TEMPLATE_TYPE` to scope the lookup to article template groups.

#### BC Breaks/Deprecations

Minimum `sulu/sulu` version raised from `^3.0` to `^3.0.7`. Projects on 3.0.0–3.0.6 cannot install this version of the bundle and must upgrade `sulu/sulu` first.
